### PR TITLE
Return virtual_facts after VMware platform detection

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -245,6 +245,7 @@ class LinuxVirtual(Virtual):
                 if vendor_name.startwith('VMware'):
                     virtual_facts['virtualization_type'] = 'VMware'
                     virtual_facts['virtualization_role'] = 'guest'
+                    return virtual_facts
 
         # If none of the above matches, return 'NA' for virtualization_type
         # and virtualization_role. This allows for proper grouping.


### PR DESCRIPTION
##### SUMMARY
We need to return virtual_facts after VMware platform detection, otherwise we're falling back to 'NA' type and role

This is an addition to PR #34925 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
virtual_facts

##### ANSIBLE VERSION
```
2.6.0 0.0.devel
```


##### ADDITIONAL INFORMATION
